### PR TITLE
chore: upgrade mdbook and mdbook-i18n-helpers

### DIFF
--- a/.github/workflows/install-mdbook/action.yml
+++ b/.github/workflows/install-mdbook/action.yml
@@ -8,9 +8,9 @@ runs:
     # The --locked flag is important for reproducible builds. It also
     # avoids breakage due to skews between mdbook and mdbook-svgbob.
     - name: Install mdbook
-      run: cargo install mdbook --locked --version 0.4.37
+      run: cargo install mdbook --locked --version 0.4.40
       shell: bash
 
     - name: Install mdbook-i18n-helpers
-      run: cargo install mdbook-i18n-helpers --locked --version 0.3.1
+      run: cargo install mdbook-i18n-helpers --locked --version 0.3.5
       shell: bash


### PR DESCRIPTION
Just make sure mdbook-i18n-helpers >= 0.3.3 to avoid error[E0282]: type annotations needed for `Box<_>`

See Also: 
- https://github.com/time-rs/time/issues/681
- https://github.com/google/mdbook-i18n-helpers/pull/198